### PR TITLE
Passing the Packer version from outside.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,9 @@ This is a Docker image containing the following tools:
 All these tools are used to succesfully build AWS images for the Skyscrapers customers.
 The Racker tool is used to deep merge a generic (Ruby) template with 
 customer specific extensions before generating a JSON Packer template.
+
+To build this image, a build argument is required:
+* `PACKER_VERSION`
+
+You can specify it in a manual build like this:
+`$ docker build --build-arg PACKER_VERSION=1.0.4 -t skyscrapers/packer:1.0.4 .`

--- a/packer/Dockerfile
+++ b/packer/Dockerfile
@@ -1,4 +1,9 @@
 FROM ruby:2.4.1-alpine3.6
+ARG PACKER_VERSION
+
+RUN \
+# Check for mandatory build arguments
+    : "${PACKER_VERSION:?PACKER_VERSION needs to be set and non-empty. See README.md}"
 
 RUN set -ex \
 	\
@@ -6,6 +11,7 @@ RUN set -ex \
         bash \
         gcc \
         git \
+        jq \
         libc-dev \
         make \
 		openssh \
@@ -13,10 +19,6 @@ RUN set -ex \
         ruby-dev \
         wget \
     && gem install json r10k --no-ri --no-rdoc
-
-# Adding Packer. Copied from https://github.com/hashicorp/docker-hub-images/blob/master/packer/Dockerfile-light
-ENV PACKER_VERSION=1.0.4
-ENV PACKER_SHA256SUM=0e10169ef9cf3fd55dcc9dc213b9995170f7712e8a162ca2f5109d62bfbe7529
 
 RUN set -ex \
     && wget --quiet https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip \


### PR DESCRIPTION
Use the Docker `--build-arg` option to pass arguments from the outside. Using a test very early in the Dockerfile to prevent wasting time when the argument is not specified.
