### PR TITLE
Add support for Vault using the AWS auth backend

### DIFF
--- a/concourse/Dockerfile
+++ b/concourse/Dockerfile
@@ -1,7 +1,7 @@
 FROM concourse/concourse
 
 # This is the release of Vault to pull in.
-ENV VAULT_VERSION=0.9.0
+ARG VAULT_VERSION=0.9.0
 
 ADD entrypoint.sh /opt/entrypoint.sh
 
@@ -18,6 +18,6 @@ RUN apt-get update && \
     curl -s "https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_SHA256SUMS.sig" -o "vault_${VAULT_VERSION}_SHA256SUMS.sig" && \
     gpg --batch --verify vault_${VAULT_VERSION}_SHA256SUMS.sig vault_${VAULT_VERSION}_SHA256SUMS && \
     grep vault_${VAULT_VERSION}_linux_amd64.zip vault_${VAULT_VERSION}_SHA256SUMS | sha256sum -c && \
-    unzip -d /bin vault_${VAULT_VERSION}_linux_amd64.zip && \
+    unzip -d /bin vault_${VAULT_VERSION}_linux_amd64.zip
 
 ENTRYPOINT [ "/opt/entrypoint.sh" ]

--- a/concourse/Dockerfile
+++ b/concourse/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && \
     curl -s "https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip" -o "vault_${VAULT_VERSION}_linux_amd64.zip" && \
     curl -s "https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_SHA256SUMS" -o "vault_${VAULT_VERSION}_SHA256SUMS" && \
     curl -s "https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_SHA256SUMS.sig" -o "vault_${VAULT_VERSION}_SHA256SUMS.sig" && \
+    gpg --keyserver pgpkeys.mit.edu --recv-keys 91A6E7F85D05C65630BEF18951852D87348FFC4C && \
     gpg --batch --verify vault_${VAULT_VERSION}_SHA256SUMS.sig vault_${VAULT_VERSION}_SHA256SUMS && \
     grep vault_${VAULT_VERSION}_linux_amd64.zip vault_${VAULT_VERSION}_SHA256SUMS | sha256sum -c && \
     unzip -d /bin vault_${VAULT_VERSION}_linux_amd64.zip

--- a/concourse/Dockerfile
+++ b/concourse/Dockerfile
@@ -1,14 +1,23 @@
 FROM concourse/concourse
 
-ADD download-keys.sh /opt/download-keys.sh
+# This is the release of Vault to pull in.
+ENV VAULT_VERSION=0.9.0
+
+ADD entrypoint.sh /opt/entrypoint.sh
 
 RUN apt-get update && \
-    apt-get install -y python curl unzip && \
+    apt-get install -y python curl unzip gnupg && \
     rm -rf /var/lib/apt/lists/* && \
     curl -s "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \
     unzip awscli-bundle.zip && \
     ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
     mkdir -p /concourse-keys && \
-    chmod +x /opt/download-keys.sh
+    chmod +x /opt/entrypoint.sh && \
+    curl -s "https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip" -o "vault_${VAULT_VERSION}_linux_amd64.zip" && \
+    curl -s "https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_SHA256SUMS" -o "vault_${VAULT_VERSION}_SHA256SUMS" && \
+    curl -s "https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_SHA256SUMS.sig" -o "vault_${VAULT_VERSION}_SHA256SUMS.sig" && \
+    gpg --batch --verify vault_${VAULT_VERSION}_SHA256SUMS.sig vault_${VAULT_VERSION}_SHA256SUMS && \
+    grep vault_${VAULT_VERSION}_linux_amd64.zip vault_${VAULT_VERSION}_SHA256SUMS | sha256sum -c && \
+    unzip -d /bin vault_${VAULT_VERSION}_linux_amd64.zip && \
 
-ENTRYPOINT [ "/opt/download-keys.sh" ]
+ENTRYPOINT [ "/opt/entrypoint.sh" ]

--- a/concourse/download-keys.sh
+++ b/concourse/download-keys.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-set -e
-
-if [ ! -z ${_CONCOURSE_KEYS_S3} ]; then aws s3 cp --recursive ${_CONCOURSE_KEYS_S3} /concourse-keys; fi;
-
-/usr/local/bin/concourse "$@"

--- a/concourse/entrypoint.sh
+++ b/concourse/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -7,7 +7,7 @@ if [ ! -z ${_CONCOURSE_KEYS_S3} ]; then aws s3 cp --recursive ${_CONCOURSE_KEYS_
 ## To be removed when concourse fully supports the AWS auth backend
 ## https://github.com/concourse/concourse/issues/1367
 if [ ! -z ${CONCOURSE_VAULT_URL} ] && [ "${CONCOURSE_VAULT_AUTH_BACKEND}" == "aws" ]; then
-  export CONCOURSE_VAULT_CLIENT_TOKEN="$(/bin/vault auth -token-only -method=aws `echo -n ${CONCOURSE_VAULT_AUTH_PARAM} | tr ',' ' '`)"
+  export CONCOURSE_VAULT_CLIENT_TOKEN="$(VAULT_ADDR=${CONCOURSE_VAULT_URL} /bin/vault auth -token-only -method=aws `echo -n ${CONCOURSE_VAULT_AUTH_PARAM} | tr ',' ' '`)"
   unset CONCOURSE_VAULT_AUTH_BACKEND
   unset CONCOURSE_VAULT_AUTH_PARAM
 fi

--- a/concourse/entrypoint.sh
+++ b/concourse/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -e
+
+if [ ! -z ${_CONCOURSE_KEYS_S3} ]; then aws s3 cp --recursive ${_CONCOURSE_KEYS_S3} /concourse-keys; fi;
+
+## To be removed when concourse fully supports the AWS auth backend
+## https://github.com/concourse/concourse/issues/1367
+if [ ! -z ${CONCOURSE_VAULT_URL} ] && [ "${CONCOURSE_VAULT_AUTH_BACKEND}" == "aws" ]; then
+  export CONCOURSE_VAULT_CLIENT_TOKEN="$(/bin/vault auth -token-only -method=aws `echo -n ${CONCOURSE_VAULT_AUTH_PARAM} | tr ',' ' '`)"
+  unset CONCOURSE_VAULT_AUTH_BACKEND
+  unset CONCOURSE_VAULT_AUTH_PARAM
+fi
+
+/usr/local/bin/concourse "$@"


### PR DESCRIPTION
At the moment Concourse doesn't support the AWS auth backend for Vault, according to this GH issue: https://github.com/concourse/concourse/issues/1367

This will use vault cli to fetch a token using the AWS auth backend (if specified via the normal Concourse variables) and will feed it to Concourse. 

It can be reverted once Concourse fully supports the AWS auth backend logic.