### PR TITLE
Add Teleport Dockerfile + ci script 

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,9 @@ To build this image, a build argument is required:
 
 You can specify it in a manual build like this:
 `$ docker build --build-arg PACKER_VERSION=1.0.4 -t skyscrapers/packer:1.0.4 .`
+
+## Teleport
+
+This is a Docker image for [Teleport](https://gravitational.com/teleport/)
+
+This will build a Teleport image from the Debian base image. This Dockerfile expects the released Teleport binaries in `teleport/teleport` folder.

--- a/ci/prepare-teleport-release.yml
+++ b/ci/prepare-teleport-release.yml
@@ -1,0 +1,18 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: "debian"
+    tag: "jessie"
+inputs:
+  - name: teleport-release
+  - name: docker-teleport
+run:
+  path: sh
+  args:
+  - -exc
+  - |
+    VERSION=$(cat teleport-release/version)
+    tar -xzf teleport-release/teleport-$VERSION-linux-amd64-bin.tar.gz
+    mv teleport-release/teleport docker-teleport/teleport

--- a/teleport/Dockerfile
+++ b/teleport/Dockerfile
@@ -1,7 +1,5 @@
 FROM debian:jessie
 
-# ARG TELEPORT_VERSION
-
 ADD teleport/tsh /usr/local/bin/tsh
 ADD teleport/tctl /usr/local/bin/tctl
 ADD teleport/teleport /usr/local/bin/teleport

--- a/teleport/Dockerfile
+++ b/teleport/Dockerfile
@@ -1,0 +1,9 @@
+FROM debian:jessie
+
+# ARG TELEPORT_VERSION
+
+ADD teleport/tsh /usr/local/bin/tsh
+ADD teleport/tctl /usr/local/bin/tctl
+ADD teleport/teleport /usr/local/bin/teleport
+
+ENTRYPOINT ["/usr/local/bin/teleport", "start"]


### PR DESCRIPTION
This is a Dockerfile which expects the teleport binaries to be in the `teleport` folder.
A ci script is added to make this possible with ConcourseCI