### PR TITLE
Added option to set advertise_ip with the EC2 host IP for teleport

### DIFF
--- a/teleport/Dockerfile
+++ b/teleport/Dockerfile
@@ -7,7 +7,8 @@ ENV DYNAMODB_REGION="eu-west-1" \
     DATA_DIR="/var/lib/teleport" \
     LOG_OUTPUT="stdout" \
     LOG_SEVERITY="ERROR" \
-    CREATE_ADMIN_USER="yes"
+    CREATE_ADMIN_USER="yes" \
+    ADVERTISE_EC2_IP="yes"
 
 ADD teleport/tsh /usr/local/bin/tsh
 ADD teleport/tctl /usr/local/bin/tctl
@@ -18,7 +19,7 @@ ADD teleport.yaml /etc/teleport_template.yaml
 
 RUN chmod +x /opt/entrypoint.sh && \
     apt-get update && \
-    apt-get install -y gettext-base ca-certificates && \
+    apt-get install -y gettext-base ca-certificates curl && \
     rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["/opt/entrypoint.sh"]

--- a/teleport/README.md
+++ b/teleport/README.md
@@ -15,3 +15,4 @@ This image will run [Teleport](https://gravitational.com/teleport/). Configurati
 - `$LOG_OUTPUT` (optional): Logging configuration, possible output values are `stdout`, `stderr` and `syslog`. Defaults to `stdout`
 - `$LOG_SEVERITY` (optional): Logging configuration, possible severity values are `INFO`, `WARN` and `ERROR`. Defaults to `ERROR`
 - `$CREATE_ADMIN_USER` (optional): If set to `"yes"` it will create a teleport user named admin and put the login url in the logs. Defaults to `"yes"`
+- `$ADVERTISE_EC2_IP` (optional): If set to `"yes"` it will set the teleport `advertise_ip` configuration with the IP of the EC2 host this container is running. It'll use `curl -s http://169.254.169.254/latest/meta-data/local-ipv4` to fetch the IP address. Defaults to `"yes"`

--- a/teleport/entrypoint.sh
+++ b/teleport/entrypoint.sh
@@ -73,4 +73,11 @@ if [ "${ENABLE_AUTH}" == "yes" ] && [ "${CREATE_ADMIN_USER}" == "yes" ]; then
   create_admin_user &
 fi
 
+if [ "${ADVERTISE_EC2_IP}" == "yes" ]; then
+  ADVERTISE_IP_="advertise_ip: $(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)"
+else
+  ADVERTISE_IP_=""
+fi
+export ADVERTISE_IP_
+
 exec /usr/local/bin/teleport start -c /etc/teleport.yaml

--- a/teleport/teleport.yaml
+++ b/teleport/teleport.yaml
@@ -14,6 +14,8 @@ teleport:
 
   ${AUTH_TOKEN_}
 
+  ${ADVERTISE_IP_}
+
   # Teleport throttles all connections to avoid abuse. These settings allow
   # you to adjust the default limits
   connection_limits:


### PR DESCRIPTION
This will use the ECS host IP address to register the Teleport node servers to the cluster.