### PR TITLE
change gpg server

### DIFF
--- a/concourse/Dockerfile
+++ b/concourse/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && \
     curl -s "https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip" -o "vault_${VAULT_VERSION}_linux_amd64.zip" && \
     curl -s "https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_SHA256SUMS" -o "vault_${VAULT_VERSION}_SHA256SUMS" && \
     curl -s "https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_SHA256SUMS.sig" -o "vault_${VAULT_VERSION}_SHA256SUMS.sig" && \
-    gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys 91A6E7F85D05C65630BEF18951852D87348FFC4C && \
+    gpg --keyserver hkp://eu.pool.sks-keyservers.net:80 --recv-keys 91A6E7F85D05C65630BEF18951852D87348FFC4C && \
     gpg --batch --verify vault_${VAULT_VERSION}_SHA256SUMS.sig vault_${VAULT_VERSION}_SHA256SUMS && \
     grep vault_${VAULT_VERSION}_linux_amd64.zip vault_${VAULT_VERSION}_SHA256SUMS | sha256sum -c && \
     unzip -d /bin vault_${VAULT_VERSION}_linux_amd64.zip


### PR DESCRIPTION
Currently, the SKS key server pgp.mit.edu is down, which is causing builds to fail. This change removes the dependency from the MIT server to [a pool](https://sks-keyservers.net/overview-of-pools.php)