### PR TITLE
Update kops image binaries to latest version

### DIFF
--- a/kops/Dockerfile
+++ b/kops/Dockerfile
@@ -1,8 +1,8 @@
 FROM alpine:latest
 
-ARG AWSCLI_VERSION=1.16.97
-ARG KOPS_VERSION=1.11.0
-ARG KUBECTL_VERSION=v1.13.3
+ARG AWSCLI_VERSION=1.16.116
+ARG KOPS_VERSION=1.11.1
+ARG KUBECTL_VERSION=v1.13.4
 
 RUN  apk add --update --no-cache bash python jq ca-certificates groff less \
   && apk add --update --no-cache --virtual build-deps py-pip curl \


### PR DESCRIPTION
Update awscli, kops and kubectl to their newest versions. Required for https://github.com/skyscrapers/engineering/issues/77 and https://github.com/skyscrapers/engineering/issues/201