### PR TITLE
Make use of Concourse oci builds engineering#208

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -1,0 +1,22 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    repository: vito/oci-build-task
+
+inputs:
+  - name: context
+    path: .
+
+outputs:
+  - name: image
+
+params:
+  - name: CONTEXT
+
+caches:
+  - path: cache
+
+run: { path: build }

--- a/build.yml
+++ b/build.yml
@@ -9,7 +9,6 @@ image_resource:
 inputs:
   - name: context
     path: .
-
 outputs:
   - name: image
 


### PR DESCRIPTION
A generic Concourse task to do the docker builds using https://github.com/vito/oci-build-task