### PR TITLE
Add kubeaudit dockerfile

### DIFF
--- a/kubeaudit/Dockerfile
+++ b/kubeaudit/Dockerfile
@@ -1,0 +1,4 @@
+ARG KUBEAUDIT_BIN_PATH=kubeaudit
+FROM scratch
+COPY ${KUBEAUDIT_BIN_PATH} /
+ENTRYPOINT ["/kubeaudit"]


### PR DESCRIPTION
This is to build a kubeaudit docker image, as an official one doesn't exist.