### PR TITLE
Build fluent-bit with patched loki output

### DIFF
--- a/fluent-bit/Dockerfile
+++ b/fluent-bit/Dockerfile
@@ -1,9 +1,26 @@
 ARG FLB_VERSION=1.8.10
+
+## LOKI PLUGIN BUILDER
+
+FROM golang:1.17 as builder_loki
+
+ARG LOKI_PLUGIN_GIT="https://github.com/sencha-dev/loki.git"
+ARG LOKI_PLUGIN_BRANCH="feature/fluent-bit-json-parse-tag"
+
+WORKDIR /go/src/app
+
+RUN git clone $LOKI_PLUGIN_GIT loki && \
+  cd loki/ && \
+  git checkout $LOKI_PLUGIN_BRANCH && \
+  make fluent-bit-plugin
+
+## FLUENT-BIT
+
 FROM fluent/fluent-bit:${FLB_VERSION}
 
 COPY plugins.conf /fluent-bit/etc/plugins.conf
 COPY --from=logzio/fluent-bit-output:latest /fluent-bit/bin/out_logzio.so /fluent-bit/plugins/out_logzio.so
-COPY --from=grafana/fluent-bit-plugin-loki:latest /fluent-bit/bin/out_grafana_loki.so /fluent-bit/plugins/out_grafana_loki.so
+COPY --from=builder_loki /go/src/app/loki/clients/cmd/fluent-bit/out_grafana_loki.so /fluent-bit/plugins/out_grafana_loki.so
 
 EXPOSE 2020
 CMD [ "/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/fluent-bit.conf" ]


### PR DESCRIPTION
Related to https://github.com/skyscrapers/engineering/issues/727

We're running into this issue: https://github.com/grafana/loki/issues/4771, so need to use a patched plugin.

```
Sending build context to Docker daemon  3.584kB
Step 1/12 : ARG FLB_VERSION=1.8.10
Step 2/12 : FROM golang:1.17 as builder_loki
 ---> 8b86bf336a01
Step 3/12 : ARG LOKI_PLUGIN_GIT="https://github.com/sencha-dev/loki.git"
 ---> Running in e01a47c4daee
Removing intermediate container e01a47c4daee
 ---> 3e3b4423c1f1
Step 4/12 : ARG LOKI_PLUGIN_BRANCH="feature/fluent-bit-json-parse-tag"
 ---> Running in 9268b01a70f5
Removing intermediate container 9268b01a70f5
 ---> c7bc5e8e19af
Step 5/12 : WORKDIR /go/src/app
 ---> Running in 5f8fe30eb184
Removing intermediate container 5f8fe30eb184
 ---> 9c0ca23af21d
Step 6/12 : RUN git clone $LOKI_PLUGIN_GIT loki &&   cd loki/ &&   git checkout $LOKI_PLUGIN_BRANCH &&   make fluent-bit-plugin
 ---> Running in c8f1a69dad05
Cloning into 'loki'...
Switched to a new branch 'feature/fluent-bit-json-parse-tag'
Branch 'feature/fluent-bit-json-parse-tag' set up to track remote branch 'feature/fluent-bit-json-parse-tag' from 'origin'.
go build -ldflags "-s -w -X github.com/grafana/loki/pkg/util/build.Branch=feature/fluent-bit-json-parse-tag -X github.com/grafana/loki/pkg/util/build.Version=feature-fluent-bit-json-parse-tag-3972f4b -X github.com/grafana/loki/pkg/util/build.Revision=3972f4b1e -X github.com/grafana/loki/pkg/util/build.BuildUser=root@c8f1a69dad05 -X github.com/grafana/loki/pkg/util/build.BuildDate=2022-01-20T10:42:12Z" -tags netgo -mod=vendor -buildmode=c-shared -o clients/cmd/fluent-bit/out_grafana_loki.so ./clients/cmd/fluent-bit/
Removing intermediate container c8f1a69dad05
 ---> 6b3272884a19
Step 7/12 : FROM fluent/fluent-bit:${FLB_VERSION}
 ---> 34692a3e3258
Step 8/12 : COPY plugins.conf /fluent-bit/etc/plugins.conf
 ---> Using cache
 ---> a5409e1ebe16
Step 9/12 : COPY --from=logzio/fluent-bit-output:latest /fluent-bit/bin/out_logzio.so /fluent-bit/plugins/out_logzio.so
 ---> Using cache
 ---> f5ba11028710
Step 10/12 : COPY --from=builder_loki /go/src/app/loki/clients/cmd/fluent-bit/out_grafana_loki.so /fluent-bit/plugins/out_grafana_loki.so
 ---> ad4c03adddce
Step 11/12 : EXPOSE 2020
 ---> Running in b3319cdc9923
Removing intermediate container b3319cdc9923
 ---> 12da108c2b59
Step 12/12 : CMD [ "/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/fluent-bit.conf" ]
 ---> Running in b1801d02f2db
Removing intermediate container b1801d02f2db
 ---> 6a6953d4020f
Successfully built 6a6953d4020f
```