### PR TITLE
terraform-resource: Use an older kubectl version

### DIFF
--- a/terraform-resource/Dockerfile
+++ b/terraform-resource/Dockerfile
@@ -2,9 +2,11 @@ ARG TF_VERSION=1.1.9
 
 FROM ljfranklin/terraform-resource:${TF_VERSION}
 
+ARG KUBECTL_VERSION=v1.22.10
+
 # Install kubectl (same version of aws esk)
 # https://github.com/alpine-docker/k8s/blob/master/Dockerfile
-RUN curl -sLO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
+RUN curl -sLO "https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl" && \
   mv kubectl /usr/bin/kubectl && \
   chmod +x /usr/bin/kubectl
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
Don't install the latest kubectl version, but one matching the K8s clusters we manage. This is mostly a temporary workaround to unblock our pipelines, until we move to a baseimage where we can use AWSCLIv2

Workaround for:
```
Error: Kubernetes cluster unreachable: exec plugin: invalid apiVersion "client.authentication.k8s.io/v1alpha1"
```

# Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
/

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

# How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have followed the PR process as described [here](https://github.com/skyscrapers/documentation/blob/master/coding_guidelines/git.md#pull-requests)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
