### PR TITLE
Fix yq

### DIFF
--- a/yq/Dockerfile
+++ b/yq/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-RUN apk -v --update add py-pip jq && \
+RUN apk -v --update add python3 py-pip jq && \
   pip install --upgrade yq && \
   apk -v --purge del py-pip && \
   rm /var/cache/apk/*


### PR DESCRIPTION
Added python3 apk package, because yq needs a valid python installation.

# Description

The latest change in [8f187a0](https://github.com/skyscrapers/docker-images/commit/8f187a001d5cc71fa075bb7ee9fca7544eb85606) removed the python environment needed to run yq and friends. The currently published image fails with a somewhat cryptic error as a result:

> standard_init_linux.go:228: exec user process caused: no such file or directory

This re-adds python through the python3 package to fix this.