### PR TITLE
Remove grafana_loki output plugin from FLB

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ Docker image containing the [aws-nuke](https://github.com/rebuy-de/aws-nuke) bin
 
 ## fluent-bit
 
-A [fluent-bit](https://github.com/fluent/fluent-bit) image including the [logzio-output](https://github.com/logzio/fluent-bit-logzio-output) and [grafana-loki](https://github.com/grafana/loki/tree/main/clients/cmd/fluent-bit) output plugins.
+A [fluent-bit](https://github.com/fluent/fluent-bit) image including the [logzio-output](https://github.com/logzio/fluent-bit-logzio-output) output plugin.
 
 You can control which versions are built via the following `ARG`s:
 
 ```docker
-ARG FLB_VERSION=1.8.11-debug
+ARG FLB_VERSION=2.2.1-debug
 ```
 
 ## kubectl

--- a/fluent-bit/Dockerfile
+++ b/fluent-bit/Dockerfile
@@ -1,9 +1,8 @@
-ARG FLB_VERSION=1.8.10
+ARG FLB_VERSION=2.2.1
 FROM fluent/fluent-bit:${FLB_VERSION}
 
 COPY plugins.conf /fluent-bit/etc/plugins.conf
 COPY --from=logzio/fluent-bit-output:latest /fluent-bit/bin/out_logzio.so /fluent-bit/plugins/out_logzio.so
-COPY --from=grafana/fluent-bit-plugin-loki:latest /fluent-bit/bin/out_grafana_loki.so /fluent-bit/plugins/out_grafana_loki.so
 
 EXPOSE 2020
 CMD [ "/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/fluent-bit.conf" ]

--- a/fluent-bit/plugins.conf
+++ b/fluent-bit/plugins.conf
@@ -1,3 +1,2 @@
 [PLUGINS]
   Path /fluent-bit/plugins/out_logzio.so
-  Path /fluent-bit/plugins/out_grafana_loki.so


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
We no longer need the custom Loki output plugin, as we've since moved completely to the [built-in loki plugin](https://docs.fluentbit.io/manual/pipeline/outputs/loki) succesfully on all our environments.

For now, we'll still keep our custom build to include the logzio plugin, instead of using the upstream container directly. Main reason is we can keep our FLB version in sync accross customers.

# Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
/

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

# How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the PR process as described [here](https://github.com/skyscrapers/documentation/blob/master/coding_guidelines/git.md#pull-requests)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
