### PR TITLE
chore: Auto trigger actions-runner and terragrunt image based on upstream releases

### DIFF
--- a/.github/workflows/publish-actions-runner-image.yml
+++ b/.github/workflows/publish-actions-runner-image.yml
@@ -7,6 +7,8 @@ on:
       - ".github/workflows/publish-actions-runner-image.yml"
     branches:
       - master
+  schedule:
+    - cron: "0 0 * * *" # Run every day at midnight
 
 env:
   REGISTRY: ghcr.io
@@ -28,7 +30,30 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fetch latest release from upstream
+        id: fetch_release
+        run: |
+          latest_release=$(curl --silent "https://api.github.com/repos/actions/runner/releases/latest" | jq -r .tag_name)
+          echo "Latest upstream release: $latest_release"
+          echo "::set-output name=upstream_release::$latest_release"
+      - name: Get the latest release from our repository
+        id: get_current_release
+        run: |
+          latest_tag=$(curl --silent -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/orgs/skyscrapers/packages/container/actions-runner/versions" | jq -r '.[0].metadata.container.tags[]' | grep -v latest | sort -rV | head -n 1)
+          echo "Current release: $latest_tag"
+          echo "::set-output name=current_release::$latest_tag"
+      - name: Compare releases
+        id: compare_releases
+        run: |
+          if [ "${{ steps.fetch_release.outputs.upstream_release }}" != "${{ steps.get_current_release.outputs.current_release }}" ]; then
+            echo "New release found: ${{ steps.fetch_release.outputs.upstream_release }}"
+            echo "::set-output name=new_release::true"
+          else
+            echo "No new release found"
+            echo "::set-output name=new_release::false"
+          fi
       - name: Build and push the container to GitHub Container Registry using the latest tag
+        if: steps.compare_releases.outputs.new_release == 'true'  || github.event_name == 'push'
         uses: docker/build-push-action@v5.3.0
         with:
           context: .
@@ -36,6 +61,8 @@ jobs:
           platforms: |
             linux/amd64
             linux/arm64
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.fetch_release.outputs.upstream_release }}
           push: true
           provenance: false

--- a/.github/workflows/publish-terragrunt-image.yml
+++ b/.github/workflows/publish-terragrunt-image.yml
@@ -7,6 +7,8 @@ on:
       - ".github/workflows/publish-terragrunt-image.yml"
     branches:
       - master
+  schedule:
+    - cron: "0 0 * * *" # Run every day at midnight
 
 env:
   REGISTRY: ghcr.io
@@ -28,7 +30,30 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fetch latest release from upstream
+        id: fetch_release
+        run: |
+          latest_release=$(curl --silent "https://api.github.com/repos/opentofu/opentofu/releases/latest" | jq -r .tag_name)
+          echo "Latest upstream release: $latest_release"
+          echo "::set-output name=upstream_release::$latest_release"
+      - name: Get the latest release from our repository
+        id: get_current_release
+        run: |
+          latest_tag=$(curl --silent -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/orgs/skyscrapers/packages/container/terragrunt/versions" | jq -r '.[0].metadata.container.tags[]' | grep -v latest | sort -rV | head -n 1)
+          echo "Current release: $latest_tag"
+          echo "::set-output name=current_release::$latest_tag"
+      - name: Compare releases
+        id: compare_releases
+        run: |
+          if [ "${{ steps.fetch_release.outputs.upstream_release }}" != "${{ steps.get_current_release.outputs.current_release }}" ]; then
+            echo "New release found: ${{ steps.fetch_release.outputs.upstream_release }}"
+            echo "::set-output name=new_release::true"
+          else
+            echo "No new release found"
+            echo "::set-output name=new_release::false"
+          fi
       - name: Build and push the container to GitHub Container Registry using the latest tag
+        if: steps.compare_releases.outputs.new_release == 'true'  || github.event_name == 'push'
         uses: docker/build-push-action@v5.3.0
         with:
           context: .
@@ -36,6 +61,10 @@ jobs:
           platforms: |
             linux/amd64
             linux/arm64
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          build-args: |
+            TOFU_VERSION=${{ steps.fetch_release.outputs.upstream_release#v }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:opentofu_${{ steps.fetch_release.outputs.upstream_release }}
           push: true
           provenance: false

--- a/atlantis/Dockerfile
+++ b/atlantis/Dockerfile
@@ -3,9 +3,9 @@ FROM ghcr.io/runatlantis/atlantis:${ATLANTIS_VERSION}
 
 USER root
 
-COPY --from=ghcr.io/skyscrapers/terragrunt:latest /usr/local/bin/sops /usr/local/bin/sops
-COPY --from=ghcr.io/skyscrapers/terragrunt:latest /usr/local/bin/tofu /usr/local/bin/tofu
-COPY --from=ghcr.io/skyscrapers/terragrunt:latest /usr/local/bin/terragrunt /usr/local/bin/terragrunt
+COPY --from=ghcr.io/skyscrapers/terragrunt:opentofu_v1.6.2 /usr/local/bin/sops /usr/local/bin/sops
+COPY --from=ghcr.io/skyscrapers/terragrunt:opentofu_v1.6.2 /usr/local/bin/tofu /usr/local/bin/tofu
+COPY --from=ghcr.io/skyscrapers/terragrunt:opentofu_v1.6.2 /usr/local/bin/terragrunt /usr/local/bin/terragrunt
 
 # Note: when atlantis moves to Alpine 3.20 update yq to yq-go: https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.20.0#yq
 RUN apk update && \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
This PR updates the pipelines for the actions-runner and terragrunt images.

For actions-runner we look at the releases of the actions/runner repo and trigger a new build if there is a new release.

For the terragrunt image we look at the releases of the opentofu/opentofu repo and trigger a new build if there is a new release and give it an additional tag opentofu_vx.x.x so we can lock it where needed.

# Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/skyscrapers/platform/issues/1204

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Actions-runner: by automating this build we will remain closer to the upstream version.
terragrunt: by tagging the build with the opentofu version we will be able to control our version upgrade better.

# How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
not

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the PR process as described [here](https://github.com/skyscrapers/documentation/blob/master/coding_guidelines/git.md#pull-requests)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
