### PR TITLE
feature: Add workflow to keep repository active with a fixed tag

### DIFF
--- a/.github/workflows/keep-repo-alive.yml
+++ b/.github/workflows/keep-repo-alive.yml
@@ -1,9 +1,6 @@
 name: Keep Repository Active with a Fixed Tag
 
 on:
-  push:
-    branches:
-      - change-1321
   schedule:
     - cron: '0 0 */59 * *'
 

--- a/.github/workflows/keep-repo-alive.yml
+++ b/.github/workflows/keep-repo-alive.yml
@@ -21,6 +21,3 @@ jobs:
         run: |
           git tag -f keepalive
           git push origin --tags --force
-
-      - name: List tags
-        run: git tag

--- a/.github/workflows/keep-repo-alive.yml
+++ b/.github/workflows/keep-repo-alive.yml
@@ -1,0 +1,29 @@
+name: Keep Repository Active with a Fixed Tag
+
+on:
+  push:
+    branches:
+      - change-1321
+  schedule:
+    - cron: '0 0 */59 * *'
+
+jobs:
+  update-tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create or update tag
+        run: |
+          git tag -f keepalive
+          git push origin --tags --force
+
+      - name: List tags
+        run: git tag


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? Any specific requirements regarding rollout?-->
Added a new workflow to keep the repo alive by taging it

# Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[1321](https://github.com/skyscrapers/platform/issues/1321)

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the PR process as described [here](https://docs.skyscrapers.eu/coding_guidelines/git/#pull-requests)
- [x] My code has been tested: 
  - [ ] Locally (please provide details if applicable)  
  - [ ] In this PR using Atlantis 
- [x] My code is ready to be applied.  
  - [ ] contains breaking changes 

> [!TIP]
> - If you’ve made any changes to the IaC, you can manually trigger Atlantis to test your changes.
> - Changes to the code in the `terraform/live` folder will automatically trigger Atlantis.
> - If you’ve made changes to the code in the `terraform/modules` folder, you can manually trigger Atlantis by commenting on the PR with: 
`atlantis plan -d terraform/live/<environment>/<project>`.
This command will trigger a plan for the specified project within the specified environment.
