### PR TITLE
fix: simplify actions-runner to single-stage build

### DIFF
--- a/actions-runner/Dockerfile
+++ b/actions-runner/Dockerfile
@@ -1,18 +1,19 @@
-FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-noble AS build
+FROM ghcr.io/actions/actions-runner:latest
 
-ARG TARGETOS
+ARG TARGETOS=linux
 ARG TARGETARCH
 ARG DEBIAN_FRONTEND=noninteractive
 USER root
 
 RUN apt-get update -y \
-  && apt-get install -y \
+  && apt-get install -y --no-install-recommends \
   jq \
   git \
   curl \
   unzip \
   zip \
-  ssh
+  openssh-client \
+  && rm -rf /var/lib/apt/lists/*
 
 RUN export RUNNER_ARCH="${TARGETARCH}" && \
   if [ "${RUNNER_ARCH}" = "amd64" ]; then export AWS_ARCH="x86_64" ; fi && \
@@ -26,25 +27,19 @@ RUN export RUNNER_ARCH="${TARGETARCH}" && \
   unzip -qq awscliv2.zip && \
   ./aws/install && \
   rm -rf \
+  awscliv2.zip \
+  aws/ \
   /usr/local/aws-cli/v2/current/dist/aws_completer \
   /usr/local/bin/aws_completer \
   /usr/local/aws-cli/v2/current/dist/awscli/data/ac.index \
   /usr/local/aws-cli/v2/current/dist/awscli/examples && \
   find /usr/local/aws-cli/v2/current/dist/awscli/botocore/data -name examples-1.json -delete
 
-RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
-  && chmod +x kubectl && mv kubectl /usr/bin/ 
-
-FROM ghcr.io/actions/actions-runner:latest
-
-COPY --from=build /usr/bin/jq /usr/bin/jq
-COPY --from=build /usr/bin/git /usr/bin/git
-COPY --from=build /usr/bin/curl /usr/bin/curl
-COPY --from=build /usr/bin/unzip /usr/bin/unzip
-COPY --from=build /usr/bin/zip /usr/bin/zip
-COPY --from=build /usr/bin/ssh* /usr/bin/
-COPY --from=build /usr/local/aws-cli/ /usr/local/aws-cli/
-COPY --from=build /usr/local/bin/ /usr/local/bin/
-COPY --from=build /usr/bin/kubectl /usr/bin/kubectl
-COPY --from=build /usr/lib/ /usr/lib/
-COPY --from=build /lib/ /lib/
+RUN curl \
+  --fail \
+  --silent \
+  --location \
+  --output kubectl \
+  "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/${TARGETARCH}/kubectl" \
+  && chmod +x kubectl \
+  && mv kubectl /usr/bin/kubectl


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? Any specific requirements regarding rollout?-->
- Replace the multi-stage build with a single stage directly on `ghcr.io/actions/actions-runner:latest`
- Eliminates binary incompatibilities when GitHub updates the runner's Ubuntu version
- Also fixes `kubectl` install which had `amd64` hardcoded instead of `${TARGETARCH}`
- Adds `--no-install-recommends` to reduce apt overhead

# Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/skyscrapers/platform/issues/1680

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the PR process as described [here](https://docs.skyscrapers.eu/docs/how-to-guides/coding_guidelines/git/#pull-requests)
- [x] My code has been tested: 
  - [x] Locally (please provide details if applicable)  
  - [ ] In this PR using Atlantis 
- [x] My code is ready to be applied.  
  - [ ] contains breaking changes 

> [!TIP]
> - If you’ve made any changes to the IaC, you can manually trigger Atlantis to test your changes.
> - Changes to the code in the `terraform/live` folder will automatically trigger Atlantis.
> - If you’ve made changes to the code in the `terraform/modules` folder, you can manually trigger Atlantis by commenting on the PR with: 
`atlantis plan -d terraform/live/<environment>/<project>`.
This command will trigger a plan for the specified project within the specified environment.
