### PR TITLE
fix: Build actions-runner as single-stage image with arch gate

### DIFF
--- a/.github/workflows/publish-actions-runner-image.yml
+++ b/.github/workflows/publish-actions-runner-image.yml
@@ -14,6 +14,12 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/actions-runner
 
+# Serialise runs so the scheduled and push-triggered builds can't race on the
+# shared :staging candidate tag.
+concurrency:
+  group: publish-actions-runner-image
+  cancel-in-progress: false
+
 jobs:
   build-latest:
     runs-on: ubuntu-latest
@@ -52,7 +58,10 @@ jobs:
             echo "No new release found"
             echo "::set-output name=new_release::false"
           fi
-      - name: Build and push the container to GitHub Container Registry using the latest tag
+      # Push a verification candidate first; it is promoted to the release tags
+      # only after every platform is confirmed runnable (see below). Runners
+      # consume :latest / the version tag, never :staging.
+      - name: Build and push the verification candidate
         if: steps.compare_releases.outputs.new_release == 'true'  || github.event_name == 'push'
         uses: docker/build-push-action@v5.3.0
         with:
@@ -62,7 +71,50 @@ jobs:
             linux/amd64
             linux/arm64
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.fetch_release.outputs.upstream_release }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:staging
           push: true
           provenance: false
+
+      # Guards against skyscrapers/platform#1965: a manifest entry held content
+      # for the wrong architecture (our runners are amd64, and the broken publish
+      # left arm64 binaries under the amd64 entry), so they died with "exec format
+      # error". Both checks below are independent of this job's own arch and of
+      # QEMU: dpkg's reported architecture must match the platform Docker was told
+      # to run, and the ELF e_machine byte (offset 18: 62=x86-64, 183=aarch64) of
+      # the entrypoint interpreter and the downloaded CLIs must match it too.
+      - name: Verify each platform before promoting
+        if: steps.compare_releases.outputs.new_release == 'true'  || github.event_name == 'push'
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:staging
+        run: |
+          set -euo pipefail
+          for arch in amd64 arm64; do
+            case "${arch}" in
+              amd64) want_em=62 ;;
+              arm64) want_em=183 ;;
+            esac
+            echo "::group::Verifying linux/${arch}"
+            docker run --rm --platform "linux/${arch}" \
+              -e EXPECTED_ARCH="${arch}" -e WANT_EM="${want_em}" "${IMAGE}" bash -c '
+                set -eu
+                got_arch="$(dpkg --print-architecture)"
+                echo "dpkg architecture: expected=${EXPECTED_ARCH} got=${got_arch}"
+                test "${got_arch}" = "${EXPECTED_ARCH}"
+                for bin in /bin/bash /usr/bin/kubectl "$(readlink -f "$(command -v aws)")"; do
+                  em="$(od -An -tu1 -j18 -N1 "${bin}" | tr -d " ")"
+                  echo "  ${bin}: e_machine=${em} (want ${WANT_EM})"
+                  test "${em}" = "${WANT_EM}"
+                done
+              '
+            echo "::endgroup::"
+          done
+
+      # Re-tag the verified manifest list (no rebuild) to the tags runners use.
+      - name: Promote verified image to release tags
+        if: steps.compare_releases.outputs.new_release == 'true'  || github.event_name == 'push'
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create \
+            --tag "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" \
+            --tag "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.fetch_release.outputs.upstream_release }}" \
+            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:staging"

--- a/actions-runner/Dockerfile
+++ b/actions-runner/Dockerfile
@@ -1,18 +1,21 @@
-FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-noble AS build
+FROM ghcr.io/actions/actions-runner:latest
 
-ARG TARGETOS
+# TARGETOS/TARGETARCH are populated automatically by buildx for each target
+# platform; declaring them here lets the arch-specific downloads below resolve.
+ARG TARGETOS=linux
 ARG TARGETARCH
 ARG DEBIAN_FRONTEND=noninteractive
 USER root
 
 RUN apt-get update -y \
-  && apt-get install -y \
+  && apt-get install -y --no-install-recommends \
   jq \
   git \
   curl \
   unzip \
   zip \
-  ssh
+  openssh-client \
+  && rm -rf /var/lib/apt/lists/*
 
 RUN export RUNNER_ARCH="${TARGETARCH}" && \
   if [ "${RUNNER_ARCH}" = "amd64" ]; then export AWS_ARCH="x86_64" ; fi && \
@@ -26,25 +29,22 @@ RUN export RUNNER_ARCH="${TARGETARCH}" && \
   unzip -qq awscliv2.zip && \
   ./aws/install && \
   rm -rf \
+  awscliv2.zip \
+  aws/ \
   /usr/local/aws-cli/v2/current/dist/aws_completer \
   /usr/local/bin/aws_completer \
   /usr/local/aws-cli/v2/current/dist/awscli/data/ac.index \
   /usr/local/aws-cli/v2/current/dist/awscli/examples && \
   find /usr/local/aws-cli/v2/current/dist/awscli/botocore/data -name examples-1.json -delete
 
-RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
-  && chmod +x kubectl && mv kubectl /usr/bin/ 
+RUN curl \
+  --fail \
+  --silent \
+  --location \
+  --output kubectl \
+  "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/${TARGETARCH}/kubectl" \
+  && chmod +x kubectl \
+  && mv kubectl /usr/bin/kubectl
 
-FROM ghcr.io/actions/actions-runner:latest
-
-COPY --from=build /usr/bin/jq /usr/bin/jq
-COPY --from=build /usr/bin/git /usr/bin/git
-COPY --from=build /usr/bin/curl /usr/bin/curl
-COPY --from=build /usr/bin/unzip /usr/bin/unzip
-COPY --from=build /usr/bin/zip /usr/bin/zip
-COPY --from=build /usr/bin/ssh* /usr/bin/
-COPY --from=build /usr/local/aws-cli/ /usr/local/aws-cli/
-COPY --from=build /usr/local/bin/ /usr/local/bin/
-COPY --from=build /usr/bin/kubectl /usr/bin/kubectl
-COPY --from=build /usr/lib/ /usr/lib/
-COPY --from=build /lib/ /lib/
+# Drop back to the unprivileged user the base image runs as.
+USER runner


### PR DESCRIPTION
# Description

Re-lands the single-stage actions-runner build that #60 attempted (reverted after it broke runners, skyscrapers/platform#1965), this time with a publish-time architecture gate so the failure cannot recur.

**What changed**

- `actions-runner/Dockerfile`: a single stage on `ghcr.io/actions/actions-runner`, installing `jq`/`git`/`curl`/`unzip`/`zip`/`openssh-client`/`aws`/`kubectl` into the runner base itself. This drops the old multi-stage trick of copying `/lib` + `/usr/lib` out of `dotnet/runtime-deps:8.0-noble` over the runner's own libraries; they matched only because both are Ubuntu 24.04 today, and a runner OS bump would mismatch glibc/loader (the goal of #60). It also fixes `kubectl` to download for `${TARGETARCH}` (it was hardcoded to `amd64`, shipping a dead x86-64 binary in the arm64 image) and resets `USER runner` (#60 left the image running as root).
- `.github/workflows/publish-actions-runner-image.yml`: the build now pushes a `:staging` candidate, each platform is verified, and only then is the manifest promoted to `:latest` and the version tag via `buildx imagetools` (no rebuild). A `concurrency` group keeps the scheduled and push builds from racing on `:staging`.

**Root cause of skyscrapers/platform#1965**

The CI log of the 2026-05-19 00:20 scheduled build shows it built arch-correct content for both platforms and pushed a proper manifest list, using the *same* runner base as the working revert. Since both images shared that base, their `run.sh`/`bash` were byte-identical, so the `exec format error` on the (amd64) runners means the published manifest delivered wrong-arch content under the amd64 entry: a publish/registry-layer fault, not a Dockerfile bug. The broken digest has since been garbage-collected and can't be byte-inspected, but the verify gate fails CI on that class of fault regardless of cause or direction.

**How the gate works**

For each platform it runs the candidate via `docker run --platform` and asserts both `dpkg --print-architecture` and the ELF `e_machine` byte (offset 18: `62`=x86-64, `183`=aarch64) of `bash`/`kubectl`/`aws`. Both are independent of the build host's own arch and of QEMU, so a wrong-arch manifest entry is caught in either direction.

**Testing**

- Built multi-arch locally and pushed `ghcr.io/skyscrapers/actions-runner:staging` (`sha256:86a6c57…`).
- Verify gate passes for both platforms: dpkg arch + ELF `e_machine` of `bash`/`kubectl`/`aws` all match (amd64=62, arm64=183).
- **amd64 (production arch):** a real ARC runner pod on skycontrol pulled `:staging` and reached `Running`/`Ready`; `/home/runner/run.sh` started cleanly with no `exec format error`.
- **arm64:** local `run.sh` execs into `Runner.Listener`; container runs as `runner`; `kubectl`/`aws` are aarch64.

# Related Issue

skyscrapers/platform#1965

# Checklist

- [x] I have followed the PR process as described [here](https://docs.skyscrapers.eu/docs/how-to-guides/coding_guidelines/git/#pull-requests)
- [x] My code has been tested:
  - [x] Locally (multi-arch build, verify gate on both arches, ran on skycontrol amd64 and local arm64)
  - [ ] In this PR using Atlantis (N/A: no IaC in this repo)
- [x] My code is ready to be applied.
  - [ ] contains breaking changes
