### PR TITLE
fix: Use TARGETARCH for spruce binary download

### DIFF
--- a/spruce/Dockerfile
+++ b/spruce/Dockerfile
@@ -1,10 +1,11 @@
 FROM alpine:latest
 ARG SPRUCE_VERSION
+ARG TARGETARCH
 
 RUN apk add -v --update bash curl python3 ca-certificates jq  yq-python coreutils && \
   yq --version
 
-RUN curl -sL "https://github.com/geofffranks/spruce/releases/download/${SPRUCE_VERSION}/spruce-linux-amd64" -o "/bin/spruce" && \
+RUN curl -sL "https://github.com/geofffranks/spruce/releases/download/${SPRUCE_VERSION}/spruce-linux-${TARGETARCH}" -o "/bin/spruce" && \
   chmod +x /bin/spruce && \
   /bin/spruce --version
 


### PR DESCRIPTION
# Description

The `spruce` Dockerfile hardcoded the `spruce-linux-amd64` binary while the workflow builds `linux/amd64,linux/arm64`, so the published arm64 image carried an amd64 executable. Switched the download to `spruce-linux-${TARGETARCH}` (set automatically by buildx); spruce releases name assets `spruce-linux-<arch>`, so it maps 1:1.

Surfaced during the EKS Graviton/arm64 audit (skyscrapers/Roadmap#27); this was the only self-built image with a broken arm64 build.

# Related Issue

skyscrapers/Roadmap#27

# Checklist

- [x] My code has been tested:
  - [x] Locally: `docker buildx build --platform linux/arm64` succeeds and `/bin/spruce --version` runs on arm64.
- [x] My code is ready to be applied.